### PR TITLE
SW-585: Use ? as a value placeholder in PostgreSQL backend

### DIFF
--- a/src/backends/postgresql/statement.cpp
+++ b/src/backends/postgresql/statement.cpp
@@ -150,6 +150,16 @@ void postgresql_statement_backend::prepare(std::string const & query,
                     state = in_name;
                 }
             }
+            /*
+             * Support also position independent parameters, where we use ? symbol, so we
+             * are compatible with Firebird backend.
+             */
+            else if (*it == '?')
+            {
+		std::ostringstream ss;
+		ss << '$' << position++;
+		query_ += ss.str();
+            }
             else // regular character, stay in the same state
             {
                 query_ += *it;


### PR DESCRIPTION
When using PostgreSQL backend, we cannot use ? as a place holder fro value parameters, but we can only specify them by name, or by position. This patch add support for ? placeholder and it replaces it by position placeholder.